### PR TITLE
Add initial fraction on initial value if missing

### DIFF
--- a/src/currency.js
+++ b/src/currency.js
@@ -74,6 +74,10 @@ class Currency {
 			throw new TypeError('The input has already been instanced. Use the static method `Currency.data(input)` to get the instance.')
 		}
 
+		// Add fraction on initial value if missing
+    const parts = String(input.value).split('.')
+    input.value = parts.length === 1 ? `${parts.shift()}.00` : `${parts.shift()}.${parts.pop().padEnd(2, '0')}`
+
 		this.input = input
 		this.events = new Set()
 


### PR DESCRIPTION
Fixes #6 

Ex for BRL:

- Make `88` get formatted as `88,00`
- Make `88.2` get formatted as `82,00`

```html
<input value="88" />
<input value="88.2" />
```